### PR TITLE
🔧 Move birdie to `dev-dependencies`

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,9 +9,9 @@ gleam = ">= 0.33.0"
 
 [dependencies]
 gleam_stdlib = "~> 0.34 or ~> 1.0"
-birdie = "~> 1.0"
 
 [dev-dependencies]
+birdie = "~> 1.0"
 gleeunit = "~> 1.0"
 
 [documentation]


### PR DESCRIPTION
I noticed that birdie gets downloaded when adding glam to a project, so here I've moved it to the `dev-dependencies` section of `gleam.toml`.